### PR TITLE
York Courier Collective now York Collective

### DIFF
--- a/data/coops.json
+++ b/data/coops.json
@@ -276,7 +276,7 @@
     }
   },
   {
-    "name": "York Courier Collective",
+    "name": "York Collective",
     "mail": "info@yorkcollective.co.uk",
     "url": "https://www.facebook.com/yorkcollective",
     "coopcycle_url": "https://york.coopcycle.org",


### PR DESCRIPTION
Name formally changed to York Collective