### PR TITLE
Small tweak to README to make steps for running the site clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm run watch
 
 ### Launch server
 
+From the root of the repo, run:
 ```
 hugo server -D
 ```


### PR DESCRIPTION
Hi there - it wasn't immediately clear from the docs where I was supposed to run the `hugo server -D` command from (as the previous command instructs you to go into `themes/coopcycle`), so I added a small tweak to the README in case anyone else gets similarly confused. Thanks for building such an awesome service!